### PR TITLE
Add target platform export package with TF FQ export

### DIFF
--- a/model_compression_toolkit/exporter/fully_quantized/keras/builder/quantize_config_to_node.py
+++ b/model_compression_toolkit/exporter/fully_quantized/keras/builder/quantize_config_to_node.py
@@ -29,6 +29,12 @@ from model_compression_toolkit.exporter.fully_quantized.keras.quantize_configs.w
 from model_compression_toolkit.exporter.fully_quantized.keras.quantize_configs.weights_quantize_config import \
     WeightsQuantizeConfig
 
+SUPPORTED_QUANTIZATION_CONFIG = [WeightsQuantizeConfig,
+                                 ActivationQuantizeConfig,
+                                 NoOpQuantizeConfig,
+                                 WeightsActivationQuantizeConfig]
+
+
 
 def get_quantization_config(node: BaseNode) -> QuantizeConfig:
     """

--- a/model_compression_toolkit/exporter/target_platform_export/__init__.py
+++ b/model_compression_toolkit/exporter/target_platform_export/__init__.py
@@ -12,10 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
-from model_compression_toolkit.core.common.constants import FOUND_TF
-
-if FOUND_TF:
-    from model_compression_toolkit.exporter.fully_quantized.keras.builder.fully_quantized_model_builder import \
-        get_fully_quantized_keras_model
-    from model_compression_toolkit.exporter.target_platform_export.keras import export_keras_fully_quantized_model

--- a/model_compression_toolkit/exporter/target_platform_export/fw_agonstic/__init__.py
+++ b/model_compression_toolkit/exporter/target_platform_export/fw_agonstic/__init__.py
@@ -12,10 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
-from model_compression_toolkit.core.common.constants import FOUND_TF
-
-if FOUND_TF:
-    from model_compression_toolkit.exporter.fully_quantized.keras.builder.fully_quantized_model_builder import \
-        get_fully_quantized_keras_model
-    from model_compression_toolkit.exporter.target_platform_export.keras import export_keras_fully_quantized_model

--- a/model_compression_toolkit/exporter/target_platform_export/fw_agonstic/exporter.py
+++ b/model_compression_toolkit/exporter/target_platform_export/fw_agonstic/exporter.py
@@ -1,0 +1,55 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+from abc import abstractmethod
+from typing import Any
+
+from model_compression_toolkit.core.common import Logger
+
+
+class Exporter:
+    """
+    Base class to define API for an Exporter class that exports and save models.
+    """
+
+    def __init__(self, model: Any):
+        """
+
+        Args:
+            model: Model to export.
+        """
+        self.model = model
+
+    @abstractmethod
+    def export(self) -> Any:
+        """
+
+        Returns: Converted model to export.
+
+        """
+        Logger.critical(f'Exporter {self.__class__} have to implement export method')
+
+    @abstractmethod
+    def save_model(self, save_model_path: str):
+        """
+        Save exported model in a given path.
+        Args:
+            save_model_path: Path to save the exported model.
+
+        Returns:
+            None.
+        """
+        Logger.critical(f'Exporter {self.__class__} have to implement save_model method')

--- a/model_compression_toolkit/exporter/target_platform_export/keras/__init__.py
+++ b/model_compression_toolkit/exporter/target_platform_export/keras/__init__.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from model_compression_toolkit.exporter.target_platform_export.keras.export_keras_fully_quantized_model import \
+    export_keras_fully_quantized_model, KerasExportMode
 
-from model_compression_toolkit.core.common.constants import FOUND_TF
 
-if FOUND_TF:
-    from model_compression_toolkit.exporter.fully_quantized.keras.builder.fully_quantized_model_builder import \
-        get_fully_quantized_keras_model
-    from model_compression_toolkit.exporter.target_platform_export.keras import export_keras_fully_quantized_model

--- a/model_compression_toolkit/exporter/target_platform_export/keras/export_keras_fully_quantized_model.py
+++ b/model_compression_toolkit/exporter/target_platform_export/keras/export_keras_fully_quantized_model.py
@@ -1,0 +1,55 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from enum import Enum
+import keras
+from model_compression_toolkit.core.common import Logger
+from model_compression_toolkit.exporter.target_platform_export.keras.exporters.fakely_quant_keras_exporter import \
+    FakelyQuantKerasExporter
+from model_compression_toolkit.exporter.target_platform_export.keras.exporters.int8_keras_exporter import Int8KerasExporter
+
+
+class KerasExportMode(Enum):
+    FAKELY_QUANT = 0
+    INT8 = 1
+
+def export_keras_fully_quantized_model(model: keras.models.Model,
+                                       mode: KerasExportMode = KerasExportMode.FAKELY_QUANT,
+                                       save_model_path: str = None):
+    """
+    Prepare and return fully quantized model for export. Save exported model to
+    a path if passed.
+
+    Args:
+        model: Model to export.
+        mode: Mode to export the model according to.
+        save_model_path: Path to save the model.
+
+    Returns:
+        Exported model.
+    """
+
+    if mode == KerasExportMode.FAKELY_QUANT:
+        exporter = FakelyQuantKerasExporter(model)
+    else:
+        Logger.critical(f'Unsupported mode was used {mode.name} to export Keras model. Please see API for supported modes.')
+
+    model = exporter.export()
+    if save_model_path is not None:
+        exporter.save_model(save_model_path)
+    return model
+
+
+
+

--- a/model_compression_toolkit/exporter/target_platform_export/keras/exporters/__init__.py
+++ b/model_compression_toolkit/exporter/target_platform_export/keras/exporters/__init__.py
@@ -13,9 +13,3 @@
 # limitations under the License.
 # ==============================================================================
 
-from model_compression_toolkit.core.common.constants import FOUND_TF
-
-if FOUND_TF:
-    from model_compression_toolkit.exporter.fully_quantized.keras.builder.fully_quantized_model_builder import \
-        get_fully_quantized_keras_model
-    from model_compression_toolkit.exporter.target_platform_export.keras import export_keras_fully_quantized_model

--- a/model_compression_toolkit/exporter/target_platform_export/keras/exporters/base_keras_exporter.py
+++ b/model_compression_toolkit/exporter/target_platform_export/keras/exporters/base_keras_exporter.py
@@ -12,10 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from model_compression_toolkit.exporter.target_platform_export.fw_agonstic.exporter import Exporter
+import keras
 
-from model_compression_toolkit.core.common.constants import FOUND_TF
+class BaseKerasExporter(Exporter):
+    """
+    Base Keras exporter class.
+    """
 
-if FOUND_TF:
-    from model_compression_toolkit.exporter.fully_quantized.keras.builder.fully_quantized_model_builder import \
-        get_fully_quantized_keras_model
-    from model_compression_toolkit.exporter.target_platform_export.keras import export_keras_fully_quantized_model
+    def __init__(self, model: keras.models.Model):
+        """
+
+        Args:
+            model: Keras model to export.
+        """
+        super().__init__(model)
+
+
+
+

--- a/model_compression_toolkit/exporter/target_platform_export/keras/exporters/fakely_quant_keras_exporter.py
+++ b/model_compression_toolkit/exporter/target_platform_export/keras/exporters/fakely_quant_keras_exporter.py
@@ -1,0 +1,124 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import keras.models
+import tensorflow as tf
+import tensorflow_model_optimization as tfmot
+from keras.engine.base_layer import Layer
+from keras.engine.input_layer import InputLayer
+from tensorflow_model_optimization.python.core.quantization.keras.default_8bit.default_8bit_quantize_configs import \
+    NoOpQuantizeConfig
+
+from model_compression_toolkit.core.common import Logger
+from model_compression_toolkit.exporter.fully_quantized.keras.builder.quantize_config_to_node import \
+    SUPPORTED_QUANTIZATION_CONFIG
+from model_compression_toolkit.exporter.fully_quantized.keras.quantize_configs.weights_quantize_config import \
+    WeightsQuantizeConfig
+from model_compression_toolkit.exporter.target_platform_export.keras.exporters.base_keras_exporter import BaseKerasExporter
+
+
+class FakelyQuantKerasExporter(BaseKerasExporter):
+    """
+    Exporter for fakely-quant Keras models.
+    """
+
+    def __init__(self, model:keras.models.Model):
+        super().__init__(model)
+
+    def export(self) -> keras.models.Model:
+        """
+        Convert fully-quantized Keras model to a fakely-quant export-ready model.
+
+        Returns:
+            Fake-quant Keras model ready to export.
+        """
+
+        def _unwrap_quantize_wrapper(layer:Layer):
+            """
+            Convert layer wrapped with QuantizeWrapper to the layer it wraps, so it's ready to export.
+
+            Args:
+                layer: Layer to unwrap.
+
+            Returns:
+                Layer after unwrapping.
+
+            """
+
+            if isinstance(layer, tfmot.quantization.keras.QuantizeWrapper):
+                # For now, we assume only weights are quantized for models to export. Activation support is in progress.
+                if isinstance(layer.layer, InputLayer):
+                    if not isinstance(layer.quantize_config, NoOpQuantizeConfig):
+                        Logger.error(
+                            f'Currently, FakelyQuantKerasExporter supports weights quantization only. Please consider '
+                            f'disabling activation quantization, until supported ')
+                    return Layer() #Identity
+
+                if not isinstance(layer.quantize_config, tuple(SUPPORTED_QUANTIZATION_CONFIG)):
+                    Logger.error(
+                        f'Only supported quantization configs are {tuple(SUPPORTED_QUANTIZATION_CONFIG)}')
+
+                # If weights are quantized, use the quantized weight for the new built layer.
+                if isinstance(layer.quantize_config, WeightsQuantizeConfig):
+                    new_layer = layer.layer.__class__.from_config(layer.layer.get_config())
+                    with tf.name_scope(new_layer.name):
+                        new_layer.build(layer.input_shape)
+
+                    # Build a list of the layer's new weights.
+                    weights_list = []
+                    for w in new_layer.weights:
+                        val = None
+                        for qw in layer.weights:
+                            if w.name in qw.name:
+                                if w.name.split('/')[-1].split(':')[0] in layer.quantize_config.weight_attrs:
+                                    val = layer.quantize_config.get_weights_and_quantizers(layer.layer)[0][1].weight
+                                else:
+                                    val = qw
+                        if val is None:
+                            Logger.error(f'Could not match weight name: {w.name}')
+                        weights_list.append(val)
+
+                    new_layer.set_weights(weights_list)
+                    new_layer.trainable = False
+                    return new_layer
+
+                elif isinstance(layer.quantize_config, NoOpQuantizeConfig):
+                    return layer.layer
+
+                else:
+                    Logger.error(
+                        f'Currently, FakelyQuantKerasExporter supports weights quantization only. Please consider '
+                        f'disabling activation quantization, until supported ')
+            else:
+                return layer
+
+        # clone each layer in the model and apply _unwrap_quantize_wrappera to layers wrapped with a QuantizeWrapper.
+        self.exported_model = tf.keras.models.clone_model(self.model,
+                                                          input_tensors=None,
+                                                          clone_function=_unwrap_quantize_wrapper)
+
+        return self.exported_model
+
+    def save_model(self, save_model_path:str):
+        """
+        Save exported model to a given path.
+        Args:
+            save_model_path: Path to save the model.
+
+        Returns:
+            None.
+        """
+        if self.exported_model is None:
+            Logger.critical(f'Exporter can not save model as it is not exported')
+        keras.models.save_model(self.exported_model, save_model_path)

--- a/model_compression_toolkit/exporter/target_platform_export/keras/exporters/int8_keras_exporter.py
+++ b/model_compression_toolkit/exporter/target_platform_export/keras/exporters/int8_keras_exporter.py
@@ -12,10 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from model_compression_toolkit.exporter.target_platform_export.keras.exporters.base_keras_exporter import BaseKerasExporter
+import keras
 
-from model_compression_toolkit.core.common.constants import FOUND_TF
+class Int8KerasExporter(BaseKerasExporter):
+    """
+    Exporter for int8 Keras models.
+    """
 
-if FOUND_TF:
-    from model_compression_toolkit.exporter.fully_quantized.keras.builder.fully_quantized_model_builder import \
-        get_fully_quantized_keras_model
-    from model_compression_toolkit.exporter.target_platform_export.keras import export_keras_fully_quantized_model
+    def export(self) -> keras.models.Model:
+        """
+        Convert fully-quantized Keras model to an int8 export-ready model.
+
+        Returns:
+            Int8 Keras model ready to export.
+        """
+        pass
+
+    def save_model(self, save_model_path: str):
+        """
+        Save exported model to a given path.
+        Args:
+            save_model_path: Path to save the model.
+
+        Returns:
+            None.
+        """
+        pass

--- a/tests/keras_tests/function_tests/test_export_keras_fully_quantized_model.py
+++ b/tests/keras_tests/function_tests/test_export_keras_fully_quantized_model.py
@@ -1,0 +1,82 @@
+# Copyright 2022 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import random
+import unittest
+
+import keras.models
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras.applications.mobilenet_v2 import MobileNetV2
+
+import model_compression_toolkit as mct
+from model_compression_toolkit.exporter.target_platform_export.keras import export_keras_fully_quantized_model, \
+    KerasExportMode
+
+import random
+import unittest
+
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras.applications.mobilenet_v2 import MobileNetV2
+
+import model_compression_toolkit as mct
+from model_compression_toolkit.exporter.target_platform_export.keras import export_keras_fully_quantized_model, \
+    KerasExportMode
+from tests.keras_tests.tpc_keras import get_activation_quantization_disabled_keras_tpc
+
+tp = mct.target_platform
+
+SAVED_MODEL_PATH = '/tmp/exported_tf.h5'
+
+
+class TestExporter(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.mbv2 = MobileNetV2()
+        self.representative_data_gen = lambda: [np.random.randn(1, 224, 224, 3)]
+        self.fully_quantized_mbv2 = self.run_mct(self.mbv2)
+        self.exported_mbv2 = export_keras_fully_quantized_model(model=self.fully_quantized_mbv2,
+                                                                mode=KerasExportMode.FAKELY_QUANT,
+                                                                save_model_path=SAVED_MODEL_PATH)
+
+    def run_mct(self, model):
+        core_config = mct.CoreConfig(n_iter=1)
+        tpc = get_activation_quantization_disabled_keras_tpc('test_keras_exporter')
+
+        new_export_model, _ = mct.keras_post_training_quantization_experimental(
+            in_model=model,
+            core_config=core_config,
+            target_platform_capabilities=tpc,
+            representative_data_gen=self.representative_data_gen,
+            new_experimental_exporter=True)
+        return new_export_model
+
+    def set_seed(self, seed):
+        tf.random.set_seed(seed)
+        np.random.seed(seed)
+        random.seed(seed)
+
+    def test_sanity(self):
+        images = self.representative_data_gen()
+        diff = self.exported_mbv2(images) - self.fully_quantized_mbv2(images)
+        print(f'Max abs error: {np.max(np.abs(diff))}')
+        self.assertTrue(np.sum(np.abs(diff)) == 0)
+
+    def test_load_model(self):
+        loaded_model = keras.models.load_model(SAVED_MODEL_PATH)
+        images = self.representative_data_gen()
+        diff = loaded_model(images) - self.fully_quantized_mbv2(images)
+        print(f'Max abs error: {np.max(np.abs(diff))}')
+        self.assertTrue(np.sum(np.abs(diff)) == 0)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -50,6 +50,8 @@ if found_tf:
     from tests.keras_tests.test_keras_tp_model import TestKerasTPModel
     from tests.keras_tests.function_tests.test_sensitivity_metric_interest_points import \
         TestSensitivityMetricInterestPoints
+    from tests.keras_tests.function_tests.test_export_keras_fully_quantized_model import TestExporter
+
 
 if found_pytorch:
     from tests.pytorch_tests.layer_tests.test_layers_runner import LayerTest as TorchLayerTest
@@ -88,6 +90,7 @@ if __name__ == '__main__':
         suiteList.append(unittest.TestLoader().loadTestsFromTestCase(TestUniformQuantizeTensor))
         suiteList.append(unittest.TestLoader().loadTestsFromTestCase(TestUniformRangeSelectionWeights))
         suiteList.append(unittest.TestLoader().loadTestsFromTestCase(TestKerasTPModel))
+        suiteList.append(unittest.TestLoader().loadTestsFromTestCase(TestExporter))
 
         # Keras test layers are supported in TF2.6 or higher versions
         if tf.__version__ >= "2.6":


### PR DESCRIPTION
Added a new package named target_platform_export.
Base Exporter class, BaseKerasExporter, and FakelyQuantKerasExporter were added.
Each exporter needs to implement export and save_model methods.
Tests were added as well.