### PR TITLE
WIP-ptq refactor

### DIFF
--- a/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_keras_exporter.py
+++ b/model_compression_toolkit/exporter/model_exporter/keras/fakely_quant_keras_exporter.py
@@ -72,48 +72,42 @@ class FakelyQuantKerasExporter(BaseKerasExporter):
             assert self.is_layer_exportable_fn(layer), f'Layer {layer.name} is not exportable.'
 
             # If weights are quantized, use the quantized weight for the new built layer.
-            if layer.is_weights_quantization:
-                new_layer = layer.layer.__class__.from_config(layer.layer.get_config())
-                with tf.name_scope(new_layer.name):
-                    new_layer.build(layer.input_shape)
+            if isinstance(layer, KerasQuantizationWrapper):
+                if layer.is_weights_quantization:
+                    new_layer = layer.layer.__class__.from_config(layer.layer.get_config())
+                    with tf.name_scope(new_layer.name):
+                        new_layer.build(layer.input_shape)
 
-                # Build a list of the layer's new weights.
-                weights_list = []
-                # Go over weights, check if they should be quantized, and quantize if this is the case:
-                for w in new_layer.weights:
-                    val = None
-                    for qw in layer.weights:
-                        if w.name in qw.name:
-                            # Use quantized weight if layer attribute should be quantized.
-                            # For example: check if 'kernel_0' is an attribute
-                            # that should be quantized. First, extract 'kernel' from variable name, check if the
-                            # quantize config contains this as an attribute for quantization. If so -
-                            # Take the quantized weight from the quantize_config and set it to the new layer.
-                            attribute_name = w.name.split('/')[-1].split(':')[0]
-                            if attribute_name in layer.weights_quantizers.keys():
-                                quantizer = layer.weights_quantizers.get(attribute_name)
-                                val = quantizer(qw)
-                            else:
-                                val = qw
-                    if val is None:
-                        Logger.error(f'Could not match weight name: {w.name}')
-                    weights_list.append(val)
+                    # Build a list of the layer's new weights.
+                    weights_list = []
+                    # Go over weights, check if they should be quantized, and quantize if this is the case:
+                    for w in new_layer.weights:
+                        val = None
+                        for qw in layer.weights:
+                            if w.name in qw.name:
+                                # Use quantized weight if layer attribute should be quantized.
+                                # For example: check if 'kernel_0' is an attribute
+                                # that should be quantized. First, extract 'kernel' from variable name, check if the
+                                # quantize config contains this as an attribute for quantization. If so -
+                                # Take the quantized weight from the quantize_config and set it to the new layer.
+                                attribute_name = w.name.split('/')[-1].split(':')[0]
+                                if attribute_name in layer.weights_quantizers.keys():
+                                    quantizer = layer.weights_quantizers.get(attribute_name)
+                                    val = quantizer(qw)
+                                else:
+                                    val = qw
+                        if val is None:
+                            Logger.error(f'Could not match weight name: {w.name}')
+                        weights_list.append(val)
 
-                new_layer.set_weights(weights_list)
-                new_layer.trainable = False
+                    new_layer.set_weights(weights_list)
+                    new_layer.trainable = False
 
-                # If activations are also quantized, wrap the layer back using ActivationQuantizeConfig
-                # from original wrapper (weights wrapping is no longer needed).
-                if layer.is_activation_quantization:
-                    new_layer = KerasQuantizationWrapper(layer=new_layer,
-                                                         activation_quantizers=layer.activation_quantizers)
-
-                return new_layer
+                    return new_layer
 
             # If this is a layer with activation quantization only, just return it
             # as activation quantization in the fake-quant case uses the wrapper for quantization.
             return layer
-
 
         # clone each layer in the model and apply _unwrap_quantize_wrapper to layers wrapped with a QuantizeWrapper.
         self.exported_model = tf.keras.models.clone_model(self.model,

--- a/model_compression_toolkit/exporter/model_wrapper/keras/builder/fully_quantized_model_builder.py
+++ b/model_compression_toolkit/exporter/model_wrapper/keras/builder/fully_quantized_model_builder.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Tuple
 
+from typing import Tuple, Callable
 from model_compression_toolkit.core import common
 from model_compression_toolkit.core.common import Graph
 from model_compression_toolkit.constants import FOUND_TF
 from model_compression_toolkit.core.common.user_info import UserInformation
 from model_compression_toolkit.logger import Logger
+from mct_quantizers import KerasActivationQuantizationHolder
 
 if FOUND_TF:
     import tensorflow as tf
@@ -32,15 +33,41 @@ if FOUND_TF:
         """
         A function which takes a computational graph node and a keras layer and perform the quantization wrapping
         Args:
-            n: A node of mct graph.
+            node: A node of mct graph.
             layer: A keras layer
-            include_activation_quantizers: Whether to use the wrapper for the activation quantizer or not
 
         Returns: Wrapped layer with weights quantizers and activation quantizers
 
         """
-        weights_quantizers, activation_quantizers = get_quantization_quantizers(node)
-        return KerasQuantizationWrapper(layer, weights_quantizers, activation_quantizers)
+        weights_quantizers, _ = get_quantization_quantizers(node)
+        if len(weights_quantizers) > 0:
+            return KerasQuantizationWrapper(layer,
+                                            weights_quantizers)
+        return layer
+
+
+    def get_activation_quantizer_holder(node: common.BaseNode) -> Callable:
+        """
+        Retrieve a ActivationQuantizationHolder layer to use for activation quantization for a node.
+
+        Args:
+            node: Node to get ActivationQuantizationHolder to attach in its output.
+
+        Returns:
+            A ActivationQuantizationHolder layer for the node activation quantization.
+        """
+        _, activation_quantizers = get_quantization_quantizers(node)
+
+        # Holder by definition uses a single quantizer for the activation quantization
+        # thus we make sure this is the only possible case (unless it's a node with no activation
+        # quantization, which in this case has an empty list).
+        if len(activation_quantizers) == 1:
+            return KerasActivationQuantizationHolder(activation_quantizers[0])
+
+        Logger.error(
+            f'ActivationQuantizationHolder supports a single quantizer but {len(activation_quantizers)} quantizers '
+            f'were found for node {node}')
+
 
 
     def get_exportable_keras_model(graph: Graph) -> Tuple[tf.keras.models.Model, UserInformation]:
@@ -56,7 +83,8 @@ if FOUND_TF:
             Exportable Keras model and user information.
         """
         exportable_model, user_info = KerasModelBuilder(graph=graph,
-                                                        wrapper=_get_wrapper).build_model()
+                                                        wrapper=_get_wrapper,
+                                                        get_activation_quantizer_holder_fn=get_activation_quantizer_holder).build_model()
         exportable_model.trainable = False
         return exportable_model, user_info
 else:

--- a/model_compression_toolkit/exporter/model_wrapper/keras/validate_layer.py
+++ b/model_compression_toolkit/exporter/model_wrapper/keras/validate_layer.py
@@ -14,12 +14,11 @@
 # ==============================================================================
 from typing import Any
 
+from keras.engine.base_layer import Layer
 
-from model_compression_toolkit.logger import Logger
+from mct_quantizers import BaseInferableQuantizer, KerasActivationQuantizationHolder
 from model_compression_toolkit.constants import FOUND_TF
-
-from mct_quantizers import BaseInferableQuantizer
-
+from model_compression_toolkit.logger import Logger
 
 if FOUND_TF:
     from keras.engine.input_layer import InputLayer
@@ -39,40 +38,34 @@ if FOUND_TF:
         if isinstance(layer, InputLayer):
             return True
 
-        valid_layer = isinstance(layer, KerasQuantizationWrapper)
+        valid_layer = isinstance(layer, Layer)
         if not valid_layer:
             Logger.error(
-                f'Exportable layer must be wrapped using KerasQuantizationWrapper, but layer {layer.name} is of type '
+                f'Exportable layer must be a Keras layer, but layer {layer.name} is of type '
                 f'{type(layer)}') # pragma: no cover
 
-        valid_weights_quantizers = isinstance(layer.weights_quantizers, dict)
-        if not valid_weights_quantizers:
-            Logger.error(
-                f'KerasQuantizationWrapper must have a weights_quantizers but has a '
-                f'{type(layer.weights_quantizers)} object') # pragma: no cover
-
-        for _, weights_quantizer in layer.weights_quantizers.items():
-            if not isinstance(weights_quantizer, BaseInferableQuantizer):
+        if isinstance(layer, KerasQuantizationWrapper):
+            valid_weights_quantizers = isinstance(layer.weights_quantizers, dict)
+            if not valid_weights_quantizers:
                 Logger.error(
-                    f'weights_quantizer must be a BaseInferableQuantizer object but has a '
-                    f'{type(weights_quantizer)} object')  # pragma: no cover
+                    f'KerasQuantizationWrapper must have a weights_quantizers but has a '
+                    f'{type(layer.weights_quantizers)} object') # pragma: no cover
 
-        valid_activation_quantizers = isinstance(layer.activation_quantizers, list)
-        if not valid_activation_quantizers:
-            Logger.error(
-                f'KerasQuantizationWrapper must have a activation_quantizers list but has a '
-                f'{type(layer.activation_quantizers)} object') # pragma: no cover
+            if len(layer.weights_quantizers) == 0:
+                Logger.error(f'KerasQuantizationWrapper must have at least one weight quantizer, but found {len(layer.weights_quantizers)} quantizers. If layer is not quantized it should be a Keras layer.')
 
-        for activation_quantizers in layer.activation_quantizers:
-            if not isinstance(activation_quantizers, BaseInferableQuantizer):
+            for _, weights_quantizer in layer.weights_quantizers.items():
+                if not isinstance(weights_quantizer, BaseInferableQuantizer):
+                    Logger.error(
+                        f'weights_quantizer must be a BaseInferableQuantizer object but has a '
+                        f'{type(weights_quantizer)} object')  # pragma: no cover
+
+        if isinstance(layer, KerasActivationQuantizationHolder):
+            if not isinstance(layer.activation_holder_quantizer, BaseInferableQuantizer):
                 Logger.error(
-                    f'activation_quantizers must be a BaseInferableQuantizer object but has a '
-                    f'{type(activation_quantizers)} object')  # pragma: no cover
-
-        quantizers = layer.activation_quantizers + list(layer.weights_quantizers.values())
-        is_valid_quantizers = all([isinstance(x, BaseInferableQuantizer) for x in quantizers])
-        if not is_valid_quantizers:
-            Logger.error(f'Found a quantizer that is not of type BaseInferableQuantizer') # pragma: no cover
+                    f'activation quantizer in KerasActivationQuantizationHolder'
+                    f' must be a BaseInferableQuantizer object but has a '
+                    f'{type(layer.activation_holder_quantizer)} object')  # pragma: no cover
 
         return True
 else:

--- a/tests/keras_tests/feature_networks_tests/feature_networks/activation_decomposition_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/activation_decomposition_test.py
@@ -40,8 +40,8 @@ class ActivationDecompositionTest(BaseKerasFeatureNetworkTest):
         return keras.Model(inputs=inputs, outputs=outputs)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0].layer
-        activation_layer = get_layers_from_model_by_type(quantized_model, layers.Activation)[0].layer
+        conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0]
+        activation_layer = get_layers_from_model_by_type(quantized_model, layers.Activation)[0]
         self.unit_test.assertTrue(conv_layer.get_config().get(ACTIVATION) == LINEAR)
         self.unit_test.assertTrue(activation_layer.get_config().get(ACTIVATION) == self.activation_function)
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/bn_folding_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/bn_folding_test.py
@@ -88,9 +88,9 @@ class BaseBatchNormalizationFolding(BaseKerasFeatureNetworkTest, ABC):
 
             quant_conv = get_layers_from_model_by_type(quantized_model, self.linear_layer)[0]
 
-        attr = 'depthwise_kernel' if isinstance(quant_conv.layer, layers.DepthwiseConv2D) else 'kernel'
-        quant_kernel = getattr(quant_conv.layer, attr)
-        quant_bias = quant_conv.layer.bias
+        attr = 'depthwise_kernel' if isinstance(quant_conv, layers.DepthwiseConv2D) else 'kernel'
+        quant_kernel = getattr(quant_conv, attr)
+        quant_bias = quant_conv.bias
 
         float_bn = float_model.layers[2]
         float_gamma = float_bn.weights[0]

--- a/tests/keras_tests/feature_networks_tests/feature_networks/conv_bn_relu_residual_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/conv_bn_relu_residual_test.py
@@ -16,6 +16,7 @@
 
 import tensorflow as tf
 
+from mct_quantizers import KerasActivationQuantizationHolder
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
 from tests.keras_tests.utils import get_layers_from_model_by_type
 
@@ -37,12 +38,11 @@ class ConvBnReluResidualTest(BaseKerasFeatureNetworkTest):
         return model
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0]
-        activation_layer = get_layers_from_model_by_type(quantized_model, layers.Activation)[0]
+        holders = get_layers_from_model_by_type(quantized_model, KerasActivationQuantizationHolder)
         add_layer = get_layers_from_model_by_type(quantized_model, layers.Add)[0]
         bn_layer = get_layers_from_model_by_type(quantized_model, layers.BatchNormalization)[0]
 
-        self.unit_test.assertTrue(conv_layer.output.ref() in [t.ref() for t in add_layer.input])
-        self.unit_test.assertTrue(activation_layer.output.ref() in [t.ref() for t in add_layer.input])
-        self.unit_test.assertTrue(isinstance(bn_layer.layer, layers.BatchNormalization)) # assert not folding
+        self.unit_test.assertTrue(holders[1].output.ref() in [t.ref() for t in add_layer.input])
+        self.unit_test.assertTrue(holders[3].output.ref() in [t.ref() for t in add_layer.input])
+        self.unit_test.assertTrue(isinstance(bn_layer, layers.BatchNormalization)) # assert not folding
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_inputs_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_model_multiple_inputs_test.py
@@ -76,7 +76,7 @@ class NestedModelMultipleInputsTest(BaseKerasFeatureNetworkTest):
             else:
                 self.unit_test.assertFalse(isinstance(l, Functional) or isinstance(l, Sequential))
         num_layers = 8
-        num_fq_layers = 1
+        num_fq_layers = 7
         self.unit_test.assertTrue(len(quantized_model.layers) == (num_layers+num_fq_layers))
         y = float_model.predict(input_x)
         y_hat = quantized_model.predict(input_x)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/nested_networks/nested_test.py
@@ -87,9 +87,9 @@ class NestedTest(BaseKerasFeatureNetworkTest):
             else:
                 self.unit_test.assertFalse(isinstance(l, Functional) or isinstance(l, Sequential))
         if self.is_inner_functional:
-            num_layers = 9
+            num_layers = 8
         else:
-            num_layers = 6
+            num_layers = 5
         self.unit_test.assertTrue(len(quantized_model.layers) == num_layers)
         y = float_model.predict(input_x)
         y_hat = quantized_model.predict(input_x)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/change_qc_attr_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/change_qc_attr_test.py
@@ -17,6 +17,7 @@ import numpy as np
 import tensorflow as tf
 from keras.engine.input_layer import InputLayer
 
+from mct_quantizers import KerasActivationQuantizationHolder
 from model_compression_toolkit.core import DebugConfig
 from model_compression_toolkit.core.common.network_editors.actions import EditRule, ChangeFinalWeightsQuantConfigAttr, \
     ChangeFinalActivationQuantConfigAttr, ChangeCandidatesActivationQuantConfigAttr
@@ -66,5 +67,5 @@ class ChangeFinalActivationQCAttrTest(BaseKerasFeatureNetworkTest):
         return model
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        conv_layer = get_layers_from_model_by_type(quantized_model, layers.Conv2D)[0]
-        self.unit_test.assertTrue(conv_layer.activation_quantizers[0].get_config()['num_bits'] == 7)
+        conv_holder_layer = get_layers_from_model_by_type(quantized_model, KerasActivationQuantizationHolder)[1]
+        self.unit_test.assertTrue(conv_holder_layer.activation_holder_quantizer.get_config()['num_bits'] == 7)

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_error_method_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_error_method_test.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 from keras.engine.base_layer import Layer
 from keras.engine.input_layer import InputLayer
 
+from mct_quantizers import KerasActivationQuantizationHolder
 from model_compression_toolkit.core import QuantizationErrorMethod, DebugConfig
 from model_compression_toolkit.core.common.network_editors.actions import EditRule, \
     ChangeCandidatesActivationQuantConfigAttr
@@ -58,8 +59,8 @@ class EditActivationErrorMethod(BaseKerasFeatureNetworkTest):
         return model
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        identity_layer = get_layers_from_model_by_type(quantized_model, Layer)[0]
-        input_q_params = identity_layer.activation_quantizers[0].get_config()
+        holder_layer = get_layers_from_model_by_type(quantized_model, KerasActivationQuantizationHolder)[0]
+        input_q_params = holder_layer.activation_holder_quantizer.get_config()
         threshold = input_q_params['threshold']
         self.unit_test.assertTrue(threshold == 2,
                                   f'After editing input layer to no clipping error method,'

--- a/tests/keras_tests/feature_networks_tests/feature_networks/qat/qat_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/qat/qat_test.py
@@ -125,7 +125,7 @@ class QuantizationAwareTrainingQuantizersTest(QuantizationAwareTrainingTest):
             dw_weight = float_model.layers[1].weights[0].numpy()
             quantized_dw_weight = dw_layers[0].weights[0].numpy()
         else:
-            self.unit_test.assertTrue(isinstance(quantized_model.layers[2], KerasActivationQuantizationHolder))
+            self.unit_test.assertTrue(isinstance(quantized_model.layers[1], KerasActivationQuantizationHolder))
             for name, quantizer in dw_layers[0].weights_quantizers.items():
                 w_select = [w for w in float_model.layers[1].weights if name + ":0" in w.name]
                 if len(w_select) != 1:

--- a/tests/keras_tests/feature_networks_tests/feature_networks/relu_replacement_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/relu_replacement_test.py
@@ -137,8 +137,8 @@ class ReluReplacementWithAddBiasTest(SingleReluReplacementTest):
         self.unit_test.assertTrue(np.isclose(6, np.mean(quantized_model.predict(input_x) - input_x)))
         add_bias_layers = get_layers_from_model_by_type(quantized_model, AddBias)
         self.unit_test.assertTrue(len(add_bias_layers) == 2)
-        self.unit_test.assertTrue(add_bias_layers[0].layer.bias == 0)
-        self.unit_test.assertTrue(add_bias_layers[1].layer.bias == 6)
+        self.unit_test.assertTrue(add_bias_layers[0].bias == 0)
+        self.unit_test.assertTrue(add_bias_layers[1].bias == 6)
 
     def get_debug_config(self):
         return mct.core.DebugConfig(network_editor=[EditRule(filter=NodeTypeFilter(layers.ReLU),

--- a/tests/keras_tests/feature_networks_tests/feature_networks/shift_neg_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/shift_neg_activation_test.py
@@ -15,6 +15,7 @@
 import model_compression_toolkit as mct
 import tensorflow as tf
 
+from mct_quantizers import KerasActivationQuantizationHolder
 from model_compression_toolkit.constants import SHIFT_NEGATIVE_NON_LINEAR_NUM_BITS
 from model_compression_toolkit.core.common.network_editors import EditRule, node_filters, actions
 from model_compression_toolkit.core.keras.default_framework_info import DEFAULT_KERAS_INFO
@@ -80,8 +81,8 @@ class ShiftNegActivationTest(BaseKerasFeatureNetworkTest):
                 # add bypass nodes
                 linear_op_index = linear_op_index + 1
                 if isinstance(bypass_op, layers.GlobalAveragePooling2D):
-                    avg_layer = get_layers_from_model_by_type(quantized_model, layers.GlobalAveragePooling2D)[0]
-                    self.unit_test.assertTrue(avg_layer.activation_quantizers[0].get_config()['signed'] == False)
+                    avg_holder_layer = get_layers_from_model_by_type(quantized_model, KerasActivationQuantizationHolder)[3]
+                    self.unit_test.assertTrue(avg_holder_layer.activation_holder_quantizer.get_config()['signed'] == False)
 
         attr = DEFAULT_KERAS_INFO.get_kernel_op_attributes(type(self.linear_op_to_test))[0]
         linear_layer = get_layers_from_model_by_type(quantized_model, type(self.linear_op_to_test))[0]
@@ -89,8 +90,8 @@ class ShiftNegActivationTest(BaseKerasFeatureNetworkTest):
 
         # Take the ACTUAL value the activations were shifted by, from the Add layer the substitution needs to insert
         tfoplambda_layers = get_layers_from_model_by_type(quantized_model, TFOpLambda)
-        add_layer = [x for x in tfoplambda_layers if x.layer.symbol=='math.add'][0]
-        shift_nl_out = add_layer.layer.inbound_nodes[0].call_args[1]
+        add_layer = [x for x in tfoplambda_layers if x.symbol=='math.add'][0]
+        shift_nl_out = add_layer.inbound_nodes[0].call_args[1]
         if isinstance(self.linear_op_to_test, layers.DepthwiseConv2D):
             self.unit_test.assertTrue(np.allclose(b - q_b, shift_nl_out * np.sum(w, axis=(0, 1)).flatten()))
         elif isinstance(self.linear_op_to_test, layers.Conv2D):
@@ -126,14 +127,14 @@ class ShiftNegActivationPostAddTest(ShiftNegActivationTest):
         self.unit_test.assertTrue(float_model.output.shape.as_list() == quantized_model.output.shape.as_list(),
                                   msg=f'Outputs shape mismatch: {float_model.output.shape} != {quantized_model.output.shape}')
 
-        non_linear_layer_fake_quant = quantized_model.layers[2]
-        non_linear_nbits = non_linear_layer_fake_quant.activation_quantizers[0].get_config()['num_bits']
+        non_linear_layer_fake_quant = quantized_model.layers[3]
+        non_linear_nbits = non_linear_layer_fake_quant.activation_holder_quantizer.get_config()['num_bits']
         self.unit_test.assertTrue(non_linear_nbits == SHIFT_NEGATIVE_NON_LINEAR_NUM_BITS,
                                   f"The non-linear node's activation_n_bits after applying snc should be "
                                   f"{SHIFT_NEGATIVE_NON_LINEAR_NUM_BITS}, but activation_n_bits is {non_linear_nbits}")
 
-        post_add_layer_fake_quant = quantized_model.layers[3]
-        post_add_nbits = post_add_layer_fake_quant.activation_quantizers[0].get_config()['num_bits']
+        post_add_layer_fake_quant = quantized_model.layers[5]
+        post_add_nbits = post_add_layer_fake_quant.activation_holder_quantizer.get_config()['num_bits']
         self.unit_test.assertTrue(post_add_nbits == self.post_add_nbits,
                                   f"The post_add layer that's added after the non-linear node "
                                   f"should be quantized with {self.post_add_nbits}, "

--- a/tests/keras_tests/feature_networks_tests/feature_networks/test_depthwise_conv2d_replacement.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/test_depthwise_conv2d_replacement.py
@@ -58,7 +58,7 @@ class DwConv2dReplacementTest(BaseKerasFeatureNetworkTest):
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         self.unit_test.assertTrue(np.isclose(0, np.mean(quantized_model.predict(input_x) - input_x)))
         dw_layer = get_layers_from_model_by_type(quantized_model, layers.DepthwiseConv2D)[0]
-        self.unit_test.assertTrue(np.all(dw_layer.layer.depthwise_kernel.numpy() == 1))
+        self.unit_test.assertTrue(np.all(dw_layer.depthwise_kernel.numpy() == 1))
 
     def get_debug_config(self):
         return mct.core.DebugConfig(network_editor=[EditRule(filter=NodeTypeFilter(layers.DepthwiseConv2D),

--- a/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/uniform_range_selection_activation_test.py
@@ -19,6 +19,7 @@ import numpy as np
 from keras.engine.base_layer import Layer
 from keras.layers import TFOpLambda
 
+from mct_quantizers import KerasActivationQuantizationHolder
 from model_compression_toolkit.target_platform_capabilities.tpc_models.default_tpc.latest import generate_keras_tpc
 from tests.common_tests.helpers.generate_test_tp_model import generate_test_tp_model
 from tests.keras_tests.feature_networks_tests.base_keras_feature_test import BaseKerasFeatureNetworkTest
@@ -55,10 +56,9 @@ class UniformRangeSelectionActivationTest(BaseKerasFeatureNetworkTest):
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
         # verify quantization range contains zero
-        identity_layers = get_layers_from_model_by_type(quantized_model, Layer)[0]
-        fake_layer_input_args = identity_layers.activation_quantizers[0].get_config()
-        add_layer = get_layers_from_model_by_type(quantized_model, TFOpLambda)[0]
-        fake_layer_add_args = add_layer.activation_quantizers[0].get_config()
+        holder_layers = get_layers_from_model_by_type(quantized_model, KerasActivationQuantizationHolder)
+        fake_layer_input_args = holder_layers[0].activation_holder_quantizer.get_config()
+        fake_layer_add_args = holder_layers[2].activation_holder_quantizer.get_config()
 
         input_layer_min, input_layer_max = fake_layer_input_args['min_range'], fake_layer_input_args['max_range']
         add_layer_min, add_layer_max = fake_layer_add_args['min_range'], fake_layer_add_args['max_range']
@@ -92,10 +92,9 @@ class UniformRangeSelectionBoundedActivationTest(UniformRangeSelectionActivation
         return keras.Model(inputs=inputs, outputs=outputs)
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):
-        identity_layer = get_layers_from_model_by_type(quantized_model, Layer)[0]
-        fake_layer_input_args = identity_layer.activation_quantizers[0].get_config()
-        softmax_layer = get_layers_from_model_by_type(quantized_model, layers.Softmax)[0]
-        fake_layer_softmax_args = softmax_layer.activation_quantizers[0].get_config()
+        holder_layers = get_layers_from_model_by_type(quantized_model, KerasActivationQuantizationHolder)
+        fake_layer_input_args = holder_layers[0].activation_holder_quantizer.get_config()
+        fake_layer_softmax_args = holder_layers[1].activation_holder_quantizer.get_config()
 
         input_layer_min, input_layer_max = fake_layer_input_args['min_range'], fake_layer_input_args['max_range']
         softmax_layer_min, softmax_layer_max = fake_layer_softmax_args['min_range'], fake_layer_softmax_args['max_range']

--- a/tests/keras_tests/function_tests/test_activation_quantization_holder_gptq.py
+++ b/tests/keras_tests/function_tests/test_activation_quantization_holder_gptq.py
@@ -49,7 +49,7 @@ class TestGPTQModelBuilderWithActivationHolder(unittest.TestCase):
     def test_adding_holder_instead_quantize_wrapper(self):
         input_shape = (8, 8, 3)
         gptq_model = self._get_gptq_model(input_shape, basic_model)
-        self.assertTrue(isinstance(gptq_model.layers[4], KerasActivationQuantizationHolder))
+        self.assertTrue(isinstance(gptq_model.layers[3], KerasActivationQuantizationHolder))
         for l in gptq_model.layers:
             if isinstance(l, KerasQuantizationWrapper):
                 self.assertTrue(len(l.activation_quantizers)==0)
@@ -57,21 +57,21 @@ class TestGPTQModelBuilderWithActivationHolder(unittest.TestCase):
     def test_adding_holders_after_reuse(self):
         input_shape = (8, 8, 3)
         gptq_model = self._get_gptq_model(input_shape, reuse_model)
+        self.assertTrue(isinstance(gptq_model.layers[3], KerasActivationQuantizationHolder))
         self.assertTrue(isinstance(gptq_model.layers[4], KerasActivationQuantizationHolder))
-        self.assertTrue(isinstance(gptq_model.layers[5], KerasActivationQuantizationHolder))
         for l in gptq_model.layers:
             if isinstance(l, KerasQuantizationWrapper):
                 self.assertTrue(len(l.activation_quantizers)==0)
 
         # Test that two holders are getting inputs from reused conv2d (the layer that is wrapped)
-        self.assertTrue(gptq_model.layers[3].layer.get_output_at(0).ref() == gptq_model.layers[4].input.ref())
-        self.assertTrue(gptq_model.layers[3].layer.get_output_at(1).ref() == gptq_model.layers[5].input.ref())
+        self.assertTrue(gptq_model.layers[2].get_output_at(0).ref() == gptq_model.layers[3].input.ref())
+        self.assertTrue(gptq_model.layers[2].get_output_at(1).ref() == gptq_model.layers[4].input.ref())
 
     def test_adding_holder_after_relu(self):
         input_shape = (8, 8, 3)
         gptq_model = self._get_gptq_model(input_shape, activation_quantization_for_relu_model)
-        self.assertTrue(isinstance(gptq_model.layers[4], ReLU))
-        self.assertTrue(isinstance(gptq_model.layers[5], KerasActivationQuantizationHolder))
+        self.assertTrue(isinstance(gptq_model.layers[3], ReLU))
+        self.assertTrue(isinstance(gptq_model.layers[4], KerasActivationQuantizationHolder))
 
 
     def _get_gptq_model(self, input_shape, get_model_fn):

--- a/tests/keras_tests/layer_tests/base_keras_layer_test.py
+++ b/tests/keras_tests/layer_tests/base_keras_layer_test.py
@@ -3,7 +3,7 @@ from typing import List, Any, Tuple
 import keras.layers
 import tensorflow as tf
 from keras.engine.base_layer import Layer
-from mct_quantizers import KerasQuantizationWrapper
+from mct_quantizers import KerasQuantizationWrapper, KerasActivationQuantizationHolder
 
 from model_compression_toolkit.ptq import keras_post_training_quantization_experimental
 from model_compression_toolkit.target_platform_capabilities.tpc_models.default_tpc.latest import generate_keras_tpc
@@ -147,40 +147,30 @@ class BaseKerasLayerTest(BaseLayerTest):
         fw_info = self.get_fw_info()
         for layer in quantized_model.layers:
             if not isinstance(layer, InputLayer):
-                assert isinstance(layer, KerasQuantizationWrapper)
-                internal_layer = layer.layer
-                op = internal_layer.function if isinstance(internal_layer, TFOpLambda) else type(internal_layer)
-                if op in KERAS_LAYER_TEST_OPS['kernel_ops']:
-                    assert len(layer.activation_quantizers) > 0
-                    for q in layer.activation_quantizers:
+                if isinstance(layer, KerasActivationQuantizationHolder):
+                    assert layer.activation_holder_quantizer.get_config()['num_bits'] == 8
+                if isinstance(layer, KerasQuantizationWrapper):
+                    # Assert the kernel op outputs are quantized
+                    assert isinstance(layer.outbound_nodes[0].layer, KerasActivationQuantizationHolder)
+                    assert len(layer.weights_quantizers) > 0
+                    for q in layer.weights_quantizers.values():
                         assert q.get_config()['num_bits'] == 8
-                    for attr in fw_info.get_kernel_op_attributes(type(internal_layer)):
+                    for attr in fw_info.get_kernel_op_attributes(type(layer.layer)):
                         self.unit_test.assertTrue(np.sum(np.abs(
-                            layer.get_quantized_weights()[attr] - getattr(float_model.get_layer(internal_layer.name), attr))) > 0.0)
-
-                elif op in KERAS_LAYER_TEST_OPS['no_quantization']:
-                    assert len(layer.activation_quantizers) == 0
-
-                elif op in KERAS_LAYER_TEST_OPS['activation'] or type(internal_layer)==Layer:
-                    assert len(layer.activation_quantizers) > 0
-                    for q in layer.activation_quantizers:
-                        assert q.get_config()['num_bits'] == 8
-
-                else:
-                    raise Exception('Layer is not in framework info')
+                            layer.get_quantized_weights()[attr] - getattr(float_model.get_layer(layer.layer.name), attr))) > 0.0)
 
     def __compare_float_mode(self, float_model, quantized_model):
         for layer_index, layer in enumerate(quantized_model.layers):
             # Check there are no fake-quant layers
-            self.unit_test.assertFalse(is_layer_fake_quant(layer))
+            self.unit_test.assertFalse(isinstance(layer, KerasActivationQuantizationHolder))
             if not isinstance(layer, InputLayer):
-                assert isinstance(layer, KerasQuantizationWrapper)
-                assert len(layer.activation_quantizers) == 0
-                assert len(layer.weights_quantizers.keys()) == 0
-                # check unchanged weights
-                if hasattr(layer.layer, 'weights') and len(layer.layer.weights) > 0:
-                    for i, w in enumerate(layer.layer.weights):
-                        self.unit_test.assertTrue(np.sum(np.abs(w - float_model.layers[layer_index-1].weights[i])) == 0.0)
+                if isinstance(layer, KerasQuantizationWrapper):
+                    assert len(layer.activation_quantizers) == 0
+                    assert len(layer.weights_quantizers.keys()) == 0
+                    # check unchanged weights
+                    if hasattr(layer.layer, 'weights') and len(layer.layer.weights) > 0:
+                        for i, w in enumerate(layer.layer.weights):
+                            self.unit_test.assertTrue(np.sum(np.abs(w - float_model.layers[layer_index-1].weights[i])) == 0.0)
 
         input_tensors = self.generate_inputs()
         y = self.predict(float_model, input_tensors)


### PR DESCRIPTION
1. Use a quantizer holder for activations instead of a wrapper during PTQ.
2. In the Keras model builder - replace layers wrapping using clone_model with building wrapped layers in OperationHandler.
3. Remove the Identity layer added for models to overcome the issue of quantizing inputs (now the holder quantizes it, and no wrapper is needed).

Exporter changes:
1. Update substitutions in Keras exporter (to stop handling activation quantizers in the wrapper and take input/output shapes from the wrapped layer since they are now inferred and not the internal layers).
2. Update the Keras validation function to consider new restrictions.